### PR TITLE
Code Indent user setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ The default values are [at the beginning of the source](https://github.com/krist
 *   `PrettyPad` (boolean, default: `false`): Uses a unicode vertical pad trick to add a half height background to code blocks. This makes copy/paste have artifacts. See [#2](https://github.com/kristopolous/Streamdown/issues/2). I like it on. But that's just me
 *   `PrettyBroken` (boolean, default: `false`): This will break the copy/paste assurance above. The output is much prettier, but it's also broken. So it's pretty broken. Works nicely with PrettyPad.
 *   `ListIndent` (integer, default: `2`): This is the recursive indent for the list styles.
+*   `CodeIndent` (integer, default: `2`): This is the indent for code blocks.
 *   `Syntax` (string, default `monokai`): This is the syntax [highlighting theme which come via pygments](https://pygments.org/styles/).
 
 Example:

--- a/streamdown/sd.py
+++ b/streamdown/sd.py
@@ -53,8 +53,9 @@ Timeout    = 0.1
 Savebrace  = true
 
 [style]
-Margin          = 2 
+Margin          = 2
 ListIndent      = 2
+CodeIndent      = 2
 PrettyPad       = true
 PrettyBroken    = true
 Width           = 0
@@ -803,7 +804,7 @@ def parse(stream):
                 indent, line_wrap = code_wrap(line)
                 
                 state.where_from = "in code"
-                pre = [state.space_left(listwidth = True), '  '] if Style.PrettyBroken else ['', '']
+                pre = [state.space_left(listwidth = True), ' ' * Style.CodeIndent] if Style.PrettyBroken else ['', '']
 
                 for tline in line_wrap:
                     # wrap-around is a bunch of tricks. We essentially format longer and longer portions of code. The problem is
@@ -1091,7 +1092,7 @@ def main():
 
     for color in ["Dark", "Mid", "Symbol", "Head", "Grey", "Bright"]:
         setattr(Style, color, apply_multipliers(style, color, H, S, V))
-    for attr in ['PrettyPad', 'PrettyBroken', 'Margin', 'ListIndent', 'Syntax']:
+    for attr in ['PrettyPad', 'PrettyBroken', 'Margin', 'ListIndent', 'CodeIndent', 'Syntax']:
         setattr(Style, attr, style.get(attr))
     for attr in ['CodeSpaces', 'Clipboard', 'Logging', 'Timeout', 'Savebrace']:
         setattr(state, attr, features.get(attr))


### PR DESCRIPTION
This allows the user to set the code block indentation and will default to 2 if not set just how it currently works. I like having it set to 0 for better copy paste support.