### PR TITLE
Move subprocess import to top level

### DIFF
--- a/streamdown/sd.py
+++ b/streamdown/sd.py
@@ -29,6 +29,7 @@ import shutil
 import traceback
 import colorsys
 import base64
+import subprocess
 from io import BytesIO
 from term_image.image import from_file, from_url
 import pygments.util
@@ -1086,7 +1087,6 @@ def main():
             import importlib.metadata
             print(importlib.metadata.version("streamdown"))
         except importlib.metadata.PackageNotFoundError:
-            import subprocess
             print(subprocess.run(
                 ['git', 'describe', '--always', '--dirty', '--tags'],
                 cwd=os.path.dirname(os.path.abspath(__file__)),


### PR DESCRIPTION
This fixes https://github.com/day50-dev/Streamdown/issues/17.

On a fresh installation, `sd --exec 'llm chat'` was failing like this:

```
$ sd --exec 'llm chat'
Exception thrown: <class 'UnboundLocalError'> cannot access local variable 'subprocess' where it is not associated with a value
Traceback (most recent call last):
  File "/Users/brian/.local/share/uv/tools/streamdown/lib/python3.12/site-packages/streamdown/sd.py", line 1137, in main
    state.exec_sub = subprocess.Popen(args.exec.split(' '), stdin=state.exec_slave, stdout=state.exec_slave, stderr=state.exec_slave, close_fds=True)
                     ^^^^^^^^^^
UnboundLocalError: cannot access local variable 'subprocess' where it is not associated with a value
```