### PR TITLE
Fix for missing the first character of each code block line with exec

### DIFF
--- a/streamdown/sd.py
+++ b/streamdown/sd.py
@@ -839,7 +839,7 @@ def parse(stream):
                     while parts[-1] in [FGRESET, FORMATRESET]:
                         parts.pop()
 
-                    tline_len = visible_length(tline)
+                    tline_len = visible_length(tline.rstrip('\r\n'))
 
                     # now we find the new stuff:
                     ttl = 0
@@ -850,7 +850,7 @@ def parse(stream):
 
                         ttl += len(idx) if idx[0] != '\x1b' else 0
 
-                        if ttl > 1+tline_len:
+                        if ttl > tline_len:
                             break
 
 


### PR DESCRIPTION
```shell
sd --exec 'printf ```\n{cat;}\n```'
```

would previously display

```
cat;}
```

while

```shell
printf ```\n{cat;}\n``` | sd
```

would correctly display

```
{cat;}
```

That's because the exec version would add a line feed `\r` in addition to the newline  `\n` at the end of the line, i.e. `\r\n`. It turns out that the calculation for the line length based on visible character widths reports a -1 for both of those whitespace characters, so the extra -1 would make the line shorter by one, thus cutting off the first character of the line.

This change strips off any trailing line feed or newline, and removes the +1 when comparing against `tline_length`, which I presume was put in to account for the newline.

I tried to test this carefully, but looking at the history it seems this section of code has had some bugs, so I'm not 100% confident I didn't introduce unexpected behavior. It might be good to double check the logic.

Thanks for the useful markdown renderer!